### PR TITLE
Update python (#9)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: "2.7"
+python: "3.8"
 install: pip install tox-travis
 script: tox
 sudo: false

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # SignalFx Enhanced RDS Monitoring Integration
 
 These instructions will describe the steps to deploy the Lambda function to
-parse and report your Enhanced RDS metrics to SignalFx. You can choose to deploy the function either from the Serverless Application Repository (recommended) or from source. Choose a deployment method and follow the steps below to encrypt your SignalFx access token, customize the metrics that will be sent to SignalFx, and create and deploy the new function. 
+parse and report your Enhanced RDS metrics to SignalFx. You can choose to deploy the function either from the Serverless Application Repository (recommended) or from source. Choose a deployment method and follow the steps below to encrypt your SignalFx access token, customize the metrics that will be sent to SignalFx, and create and deploy the new function.
 
 Before you begin, you must enable the Enhanced Monitoring option for the RDS instances you want to monitor using this integration. [Click here for instructions on enabling Enhanced Monitoring](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html).
 
@@ -10,9 +10,9 @@ Before you begin, you must enable the Enhanced Monitoring option for the RDS ins
 * [Metrics collected by this integration](#metric-groups-collected-by-this-integration)
 
 #### Note: Encryption of your SignalFx access token
-This Lambda function uses your SignalFx access token to send metrics to SignalFx, as an environment variable to the function. While Lambda encrypts all environment variables at rest and decrypts them upon invocation, AWS recommends that all sensitive information such as access tokens be encrypted using a KMS key before function deployment, and decrypted at runtime within the code. 
+This Lambda function uses your SignalFx access token to send metrics to SignalFx, as an environment variable to the function. While Lambda encrypts all environment variables at rest and decrypts them upon invocation, AWS recommends that all sensitive information such as access tokens be encrypted using a KMS key before function deployment, and decrypted at runtime within the code.
 
-Both procedures below include instructions for using either an encrypted or non-encrypted access token. 
+Both procedures below include instructions for using either an encrypted or non-encrypted access token.
 
 ## Deploying through the Serverless Application Repository
 
@@ -32,7 +32,7 @@ Search for `signalfx rds` and choose the appropriate entry based on whether you
 encrypted your access token.
 
 To access the templates directly, find the template for encrypted access
-tokens [here](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics-encrypted). 
+tokens [here](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics-encrypted).
 The template for non-encrypted access tokens is [here](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:134183635603:applications~signalfx-enhanced-rds-metrics).
 
 ### 3. Fill out application parameters
@@ -42,7 +42,7 @@ and fill out the fields accordingly.
 **Parameters for template using encrypted access tokens**
 - `EncryptedSignalFxAuthToken`: The Ciphertext blob output from your encryption of your SignalFx organization's access token
 - `KeyId`: The key id of your KMS encryption key; it is the last section of the key's ARN.
-- `SelectedMetricGroups`: The metric groups you wish to send. Enter `All` if you want all available metrics. Otherwise, list the names of desired metric groups, spelled exactly as they are below, separated by single spaces. See [Metrics collected by this integration](#metric-groups-collected-by-this-integration) for options. 
+- `SelectedMetricGroups`: The metric groups you wish to send. Enter `All` if you want all available metrics. Otherwise, list the names of desired metric groups, spelled exactly as they are below, separated by single spaces. See [Metrics collected by this integration](#metric-groups-collected-by-this-integration) for options.
 - `Realm`: Your SignalFx Realm. To determine what realm you are in, check your profile page in the SignalFx web application. Default: `us0`.
 
 **Parameters for template using non-encrypted access tokens**
@@ -57,19 +57,19 @@ For example, the endpoint for sending data in the us1 realm is ingest.us1.signal
 and ingest.eu0.signalfx.com for the eu0 realm. If you try to send data to the incorrect realm,
 your access token will be denied.
 
- 
+
 ### 4. Deploy function and configure trigger
 Click `Deploy`. Once the function has finished deploying, navigate to the
-function's main page. 
+function's main page.
 
 Under the `Configuration` tab, scroll through the list on the left and
 select CloudWatch Logs as the source of the trigger. Below there will be
-specific configurations for the trigger. 
+specific configurations for the trigger.
 
-* Select `RDSOSMetrics` as the log group. 
+* Select `RDSOSMetrics` as the log group.
 * Choose an appropriate name for the filter, and leave the filter pattern
-blank. 
-* Make sure the `Enabled` switch is activated. 
+blank.
+* Make sure the `Enabled` switch is activated.
 
 Click `Add`, then click `Save` in the upper right corner.
 
@@ -107,11 +107,11 @@ for the Lambda.
 ### 4. Create and configure the Lambda function
 From the Lambda creation screen, make sure you have selected
 `Build from scratch`. Select a name for your function. For `Runtime` select
-`Python2.7`. For the execution role, either select the role you wish to use or
+`Python3.8` (although `Python3.6` and `Python3.7` are also supported). For the execution role, either select the role you wish to use or
 select `Create from Template` and add KMS decrypt permissions if need be. You
 will also need to choose a name for the role.
 
-For subsequent tabs, follow the instructions below. 
+For subsequent tabs, follow the instructions below.
 
 #### Designer
 The only thing to be done here is set up the trigger from CloudWatch Logs.
@@ -129,13 +129,13 @@ file containing the deployment package. Change the text in `Handler` to be
 
 #### Environment variables
 
-First create an environment variable called `groups`. This will store the list of metric groups to be reported. To report all available metrics, enter `All`. Otherwise, list the names of desired metric groups, spelled exactly as above, separated by single spaces. 
+First create an environment variable called `groups`. This will store the list of metric groups to be reported. To report all available metrics, enter `All`. Otherwise, list the names of desired metric groups, spelled exactly as above, separated by single spaces.
 
-Next create a variable to store your SignalFx access token. Create a field called `encrypted_access_token` to store an encrypted SignalFx access token, or simply `access_token` to store an unencrypted token. Paste your access token into the value field. 
+Next create a variable to store your SignalFx access token. Create a field called `encrypted_access_token` to store an encrypted SignalFx access token, or simply `access_token` to store an unencrypted token. Paste your access token into the value field.
 
 If you use `encrypted_access_token`, follow the steps below to encrypt it:
-  * Under `Encryption configuration`, check the box to `Enable helpers for encryption in transit`. A new field will appear labelled `KMS key to encrypt in transit`. 
-  * Select the encryption key you wish to use from the dropdown. A button labelled `Encrypt` will appear next to your environment variables. 
+  * Under `Encryption configuration`, check the box to `Enable helpers for encryption in transit`. A new field will appear labelled `KMS key to encrypt in transit`.
+  * Select the encryption key you wish to use from the dropdown. A button labelled `Encrypt` will appear next to your environment variables.
   * Click the `Encrypt` button next to `encrypted_access_token` once. The value will be replaced by a Ciphertext blob.
 
 If you are not in the `us0` realm in SignalFx, you will need to specify a `realm` environment variable. To determine which realm you are in, check your profile page in the SignalFx web application.

--- a/enhanced_rds/lambda_script.py
+++ b/enhanced_rds/lambda_script.py
@@ -18,6 +18,7 @@ import boto3
 import gzip
 import json
 import base64
+import warnings
 from signalfx import SignalFx
 from io import StringIO
 from datetime import datetime

--- a/enhanced_rds/lambda_script.py
+++ b/enhanced_rds/lambda_script.py
@@ -91,7 +91,7 @@ def parse_timestamp(timestamp):
     :return: The timestamp in milliseconds (int).
     """
 
-    datetime_values = re.split('\D', timestamp)
+    datetime_values = re.split(r'\D', timestamp)
     datetime_values.remove('')
     datetime_values = [int(val) for val in datetime_values]
 

--- a/enhanced_rds/lambda_script.py
+++ b/enhanced_rds/lambda_script.py
@@ -93,7 +93,7 @@ def parse_timestamp(timestamp):
 
     datetime_values = re.split('\D', timestamp)
     datetime_values.remove('')
-    datetime_values = map(lambda val: int(val), datetime_values)
+    datetime_values = [int(val) for val in datetime_values]
 
     dt_timestamp = datetime(*datetime_values)
     epoch = datetime.utcfromtimestamp(0)

--- a/enhanced_rds/lambda_script.py
+++ b/enhanced_rds/lambda_script.py
@@ -19,7 +19,7 @@ import gzip
 import json
 import base64
 from signalfx import SignalFx
-from StringIO import StringIO
+from io import StringIO
 from datetime import datetime
 from metric_maps import METRICS,\
                         METRICS_MICROSOFT,\

--- a/enhanced_rds/lambda_script.py
+++ b/enhanced_rds/lambda_script.py
@@ -37,7 +37,7 @@ def e(uni_string):
     :param uni_string: Unicode to encode.
     :return: UTF-8 version of uni_string
     """
-
+    warnings.warn("Python3 uses unicode by default", DeprecationWarning)
     return uni_string.encode('utf-8')
 
 
@@ -124,7 +124,7 @@ def create_metric_entry(group, metric, value, timestamp, inst_rsrc_id,
     """
 
     entry = {
-        'metric': e(group) + '.' + e(metric),
+        'metric': group + '.' + metric,
         'value': value,
         'timestamp': parse_timestamp(timestamp),
         'dimensions': {
@@ -193,10 +193,10 @@ def parse_logs(owner_id, function_arn, log_dict, desired_metric_list,
     :return: A list of the entry dicts for this payload (list of dicts)
     """
 
-    instance_id = e(log_dict['instanceID'])
-    instance_resource_id = e(log_dict['instanceResourceID'])
+    instance_id = log_dict['instanceID']
+    instance_resource_id = log_dict['instanceResourceID']
     timestamp = log_dict['timestamp']
-    engine = e(log_dict['engine'])
+    engine = log_dict['engine']
 
     # Extract the AWS region in which this Lambda is running from the Lambda
     # ARN
@@ -282,7 +282,7 @@ def parse_process_data(process_list):
             process['cpuUsedPc'],  # % CPU
             float(process['memoryUsedPc']) / process['rss'],  # % MEM
             '0:00.00',  # CPU time
-            e(process['name'])  # Process name
+            process['name']  # Process name
         ]
         processes_data[process['id']] = process_metrics
 
@@ -306,7 +306,7 @@ def parse_payload(payload):
              object in the payload (string, dict)
     """
 
-    message_data = e(payload['awslogs']['data'])
+    message_data = payload['awslogs']['data']
     decoded_data = base64.b64decode(message_data)
 
     compressed_data = StringIO(decoded_data)
@@ -314,8 +314,8 @@ def parse_payload(payload):
         decompressed_data = f.read()
 
     log_event = json.loads(decompressed_data)
-    owner_id = e(log_event['owner'])
-    metrics_as_json = e(log_event['logEvents'][0]['message'])
+    owner_id = log_event['owner']
+    metrics_as_json = log_event['logEvents'][0]['message']
     return owner_id, json.loads(metrics_as_json)
 
 
@@ -381,7 +381,7 @@ def lambda_handler(event, context):
         owner_id, log_dict = parse_payload(event)
 
         # Creates the appropriate lists/dicts of desired metrics
-        desired_metrics_info = pull_metric_names(e(log_dict['engine']))
+        desired_metrics_info = pull_metric_names(log_dict['engine'])
 
         # Reads through the payload from logs and creates the desired metric
         # objects

--- a/enhanced_rds/lambda_script.py
+++ b/enhanced_rds/lambda_script.py
@@ -21,13 +21,13 @@ import base64
 from signalfx import SignalFx
 from io import StringIO
 from datetime import datetime
-from metric_maps import METRICS,\
-                        METRICS_MICROSOFT,\
-                        PROCESS_METRICS,\
-                        PROCESS_METRICS_MICROSOFT,\
-                        METRICS_DIMS,\
-                        METRICS_MICROSOFT_DIMS,\
-                        METRICS_AURORA_DIMS
+from .metric_maps import METRICS,\
+                         METRICS_MICROSOFT,\
+                         PROCESS_METRICS,\
+                         PROCESS_METRICS_MICROSOFT,\
+                         METRICS_DIMS,\
+                         METRICS_MICROSOFT_DIMS,\
+                         METRICS_AURORA_DIMS
 
 
 def e(uni_string):

--- a/enhanced_rds/metric_maps.py
+++ b/enhanced_rds/metric_maps.py
@@ -6,59 +6,59 @@
 
 # Standard set of metric info
 METRICS = [
-    u'cpuUtilization',
-    u'diskIO',
-    u'fileSys',
-    u'loadAverageMinute',
-    u'memory',
-    u'network',
-    u'swap',
-    u'tasks',
-    u'OSprocesses',
-    u'RDSprocesses'
+    'cpuUtilization',
+    'diskIO',
+    'fileSys',
+    'loadAverageMinute',
+    'memory',
+    'network',
+    'swap',
+    'tasks',
+    'OSprocesses',
+    'RDSprocesses'
 ]
 
 PROCESS_METRICS = [
-    u'vss',
-    u'rss',
-    u'memoryUsedPc',
-    u'cpuUsedPc'
+    'vss',
+    'rss',
+    'memoryUsedPc',
+    'cpuUsedPc'
 ]
 
 METRICS_DIMS = {
-    u'diskIO': [u'device'],
-    u'fileSys': [u'name', u'mountPoint'],
-    u'network': [u'interface']
+    'diskIO': ['device'],
+    'fileSys': ['name', 'mountPoint'],
+    'network': ['interface']
 }
 
 # Metric info for Aurora instances.
 METRICS_AURORA_DIMS = {
-    u'diskIO': [],  # Workaround to account for Aurora diskIO metrics
-    u'fileSys': [u'name', u'mountPoint'],
-    u'network': [u'interface']
+    'diskIO': [],  # Workaround to account for Aurora diskIO metrics
+    'fileSys': ['name', 'mountPoint'],
+    'network': ['interface']
 }
 
 # Metric info for Microsoft SQL instances.
 METRICS_MICROSOFT = [
-    u'cpuUtilization',
-    u'disks',
-    u'memory',
-    u'network',
-    u'OSprocesses',
-    u'RDSprocesses',
-    u'system'
+    'cpuUtilization',
+    'disks',
+    'memory',
+    'network',
+    'OSprocesses',
+    'RDSprocesses',
+    'system'
 ]
 
 PROCESS_METRICS_MICROSOFT = [
-    u'cpuUsedPc',
-    u'memUsedPc',
-    u'workingSetKb',
-    u'workingSetPrivKb',
-    u'workingSetShareableKb',
-    u'virtKb'
+    'cpuUsedPc',
+    'memUsedPc',
+    'workingSetKb',
+    'workingSetPrivKb',
+    'workingSetShareableKb',
+    'virtKb'
 ]
 
 METRICS_MICROSOFT_DIMS = {
-    u'disks': [u'name'],
-    u'network': [u'interface']
+    'disks': ['name'],
+    'network': ['interface']
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+boto3
 signalfx

--- a/tests/sample_input.py
+++ b/tests/sample_input.py
@@ -1,504 +1,504 @@
 # Sample RDSOS output from a MySQL instance
 my_sql_dict = {
-    u"engine": u"MYSQL",
-    u"instanceID": u"ppr9b9oge80i99",
-    u"instanceResourceID": u"db-H4UK4SA7E62QPMAYTMPK5XWETQ",
-    u"timestamp": u"2017-09-19T00:21:07Z",
-    u"version": 1,
-    u"uptime": u"272 days, 1:28:18",
-    u"numVCPUs": 2,
-    u"cpuUtilization": {
-        u"guest": 0,
-        u"irq": 0.72,
-        u"system": 7.25,
-        u"wait": 4.35,
-        u"idle": 78.99,
-        u"user": 3.62,
-        u"total": 21.01,
-        u"steal": 1.45,
-        u"nice": 3.62
+    "engine": "MYSQL",
+    "instanceID": "ppr9b9oge80i99",
+    "instanceResourceID": "db-H4UK4SA7E62QPMAYTMPK5XWETQ",
+    "timestamp": "2017-09-19T00:21:07Z",
+    "version": 1,
+    "uptime": "272 days, 1:28:18",
+    "numVCPUs": 2,
+    "cpuUtilization": {
+        "guest": 0,
+        "irq": 0.72,
+        "system": 7.25,
+        "wait": 4.35,
+        "idle": 78.99,
+        "user": 3.62,
+        "total": 21.01,
+        "steal": 1.45,
+        "nice": 3.62
     },
-    u"loadAverageMinute": {
-        u"fifteen": 0.4,
-        u"five": 0.3,
-        u"one": 0.29
+    "loadAverageMinute": {
+        "fifteen": 0.4,
+        "five": 0.3,
+        "one": 0.29
     },
-    u"memory": {
-        u"writeback": 0,
-        u"hugePagesFree": 0,
-        u"hugePagesRsvd": 0,
-        u"hugePagesSurp": 0,
-        u"cached": 3288068,
-        u"hugePagesSize": 2048,
-        u"free": 2746028,
-        u"hugePagesTotal": 0,
-        u"inactive": 838368,
-        u"pageTables": 5448,
-        u"dirty": 144,
-        u"mapped": 25548,
-        u"active": 3766972,
-        u"total": 7697596,
-        u"slab": 239772,
-        u"buffers": 301616
+    "memory": {
+        "writeback": 0,
+        "hugePagesFree": 0,
+        "hugePagesRsvd": 0,
+        "hugePagesSurp": 0,
+        "cached": 3288068,
+        "hugePagesSize": 2048,
+        "free": 2746028,
+        "hugePagesTotal": 0,
+        "inactive": 838368,
+        "pageTables": 5448,
+        "dirty": 144,
+        "mapped": 25548,
+        "active": 3766972,
+        "total": 7697596,
+        "slab": 239772,
+        "buffers": 301616
     },
-    u"tasks": {
-        u"sleeping": 256,
-        u"zombie": 0,
-        u"running": 4,
-        u"stopped": 0,
-        u"total": 262,
-        u"blocked": 2
+    "tasks": {
+        "sleeping": 256,
+        "zombie": 0,
+        "running": 4,
+        "stopped": 0,
+        "total": 262,
+        "blocked": 2
     },
-    u"swap": {
-        u"cached": 0,
-        u"total": 7703160,
-        u"free": 7703160
+    "swap": {
+        "cached": 0,
+        "total": 7703160,
+        "free": 7703160
     },
-    u"network": [
+    "network": [
         {
-            u"interface": u"eth0",
-            u"rx": 821640,
-            u"tx": 2856222
+            "interface": "eth0",
+            "rx": 821640,
+            "tx": 2856222
         }
     ],
-    u"diskIO": [
+    "diskIO": [
         {
-            u"writeKbPS": 20,
-            u"readIOsPS": 0,
-            u"await": 1.6,
-            u"readKbPS": 0,
-            u"rrqmPS": 0,
-            u"util": 0.8,
-            u"avgQueueLen": 0.01,
-            u"tps": 5,
-            u"readKb": 0,
-            u"device": u"rdsdev",
-            u"writeKb": 20,
-            u"avgReqSz": 4,
-            u"wrqmPS": 0,
-            u"writeIOsPS": 5
+            "writeKbPS": 20,
+            "readIOsPS": 0,
+            "await": 1.6,
+            "readKbPS": 0,
+            "rrqmPS": 0,
+            "util": 0.8,
+            "avgQueueLen": 0.01,
+            "tps": 5,
+            "readKb": 0,
+            "device": "rdsdev",
+            "writeKb": 20,
+            "avgReqSz": 4,
+            "wrqmPS": 0,
+            "writeIOsPS": 5
         }
     ],
-    u"fileSys": [
+    "fileSys": [
         {
-            u"used": 626316,
-            u"name": u"rdsfilesys",
-            u"usedFiles": 523,
-            u"usedFilePercent": 0.01,
-            u"maxFiles": 6553600,
-            u"mountPoint": u"/rdsdbdata",
-            u"total": 103053476,
-            u"usedPercent": 0.61
+            "used": 626316,
+            "name": "rdsfilesys",
+            "usedFiles": 523,
+            "usedFilePercent": 0.01,
+            "maxFiles": 6553600,
+            "mountPoint": "/rdsdbdata",
+            "total": 103053476,
+            "usedPercent": 0.61
         }
     ],
-    u"processList": [
+    "processList": [
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 765,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 765,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 766,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 766,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 780,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 780,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 781,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 781,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 3305,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 3305,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 6,
-            u"id": 4111,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 6,
+            "id": 4111,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 10888,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 10888,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 6,
-            u"id": 19825,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 6,
+            "id": 19825,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 31951,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 31951,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 32015,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 32015,
+            "rss": 703620
         },
         {
-            u"vss": 935380,
-            u"name": u"OS processes",
-            u"tgid": 0,
-            u"parentID": 0,
-            u"memoryUsedPc": 0.35,
-            u"cpuUsedPc": 0.5,
-            u"id": 0,
-            u"rss": 27824
+            "vss": 935380,
+            "name": "OS processes",
+            "tgid": 0,
+            "parentID": 0,
+            "memoryUsedPc": 0.35,
+            "cpuUsedPc": 0.5,
+            "id": 0,
+            "rss": 27824
         },
         {
-            u"vss": 1293204,
-            u"name": u"RDS processes",
-            u"tgid": 0,
-            u"parentID": 0,
-            u"memoryUsedPc": 4.27,
-            u"cpuUsedPc": 4,
-            u"id": 0,
-            u"rss": 329184
+            "vss": 1293204,
+            "name": "RDS processes",
+            "tgid": 0,
+            "parentID": 0,
+            "memoryUsedPc": 4.27,
+            "cpuUsedPc": 4,
+            "id": 0,
+            "rss": 329184
         }
     ]
 }
 
 # Sample RDSOS output from a SQL Server instance
 sql_server_dict = {
-    u"engine": u"SqlServer",
-    u"instanceID": u"trevor",
-    u"instanceResourceID": u"db-YWCA2G6UQEA3NYZ54IS6XEBGUE",
-    u"timestamp": u"2017-09-12T23:58:59Z",
-    u"version": 1,
-    u"uptime": u"0 days, 00:10:43",
-    u"numVCPUs": 1,
-    u"cpuUtilization": {
-        u"idle": 64.13,
-        u"kern": 11.85,
-        u"user": 24.01
+    "engine": "SqlServer",
+    "instanceID": "trevor",
+    "instanceResourceID": "db-YWCA2G6UQEA3NYZ54IS6XEBGUE",
+    "timestamp": "2017-09-12T23:58:59Z",
+    "version": 1,
+    "uptime": "0 days, 00:10:43",
+    "numVCPUs": 1,
+    "cpuUtilization": {
+        "idle": 64.13,
+        "kern": 11.85,
+        "user": 24.01
     },
-    u"memory": {
-        u"commitTotKb": 1073308,
-        u"commitLimitKb": 1572464,
-        u"commitPeakKb": 1109112,
-        u"physTotKb": 1048176,
-        u"physAvailKb": 125072,
-        u"sysCacheKb": 182448,
-        u"kernTotKb": 192596,
-        u"kernPagedKb": 136120,
-        u"kernNonpagedKb": 56476,
-        u"sqlServerTotKb": 123432,
-        u"pageSize": 4096
+    "memory": {
+        "commitTotKb": 1073308,
+        "commitLimitKb": 1572464,
+        "commitPeakKb": 1109112,
+        "physTotKb": 1048176,
+        "physAvailKb": 125072,
+        "sysCacheKb": 182448,
+        "kernTotKb": 192596,
+        "kernPagedKb": 136120,
+        "kernNonpagedKb": 56476,
+        "sqlServerTotKb": 123432,
+        "pageSize": 4096
     },
-    u"system": {
-        u"handles": 14874,
-        u"threads": 634,
-        u"processes": 44
+    "system": {
+        "handles": 14874,
+        "threads": 634,
+        "processes": 44
     },
-    u"disks": [
+    "disks": [
         {
-            u"name": u"rdsdbdata",
-            u"totalKb": 20838336,
-            u"usedKb": 162752,
-            u"usedPc": 0.78,
-            u"availKb": 20675584,
-            u"availPc": 99.22,
-            u"rdCountPS": 0,
-            u"rdBytesPS": 0,
-            u"wrCountPS": 0,
-            u"wrBytesPS": 0
+            "name": "rdsdbdata",
+            "totalKb": 20838336,
+            "usedKb": 162752,
+            "usedPc": 0.78,
+            "availKb": 20675584,
+            "availPc": 99.22,
+            "rdCountPS": 0,
+            "rdBytesPS": 0,
+            "wrCountPS": 0,
+            "wrBytesPS": 0
         }
     ],
-    u"network": [
+    "network": [
         {
-            u"interface": "Ethernet 2",
-            u"rdBytesPS": 0,
-            u"wrBytesPS": 0
+            "interface": "Ethernet 2",
+            "rdBytesPS": 0,
+            "wrBytesPS": 0
         }
     ],
-    u"processList": [
+    "processList": [
         {
-            u"name": u"OS processes",
-            u"cpuUsedPc": 0.3,
-            u"memUsedPc": 8.46,
-            u"workingSetKb": 249908,
-            u"workingSetPrivKb": 88728,
-            u"workingSetShareableKb": 161180,
-            u"virtKb": 57985212532
+            "name": "OS processes",
+            "cpuUsedPc": 0.3,
+            "memUsedPc": 8.46,
+            "workingSetKb": 249908,
+            "workingSetPrivKb": 88728,
+            "workingSetShareableKb": 161180,
+            "virtKb": 57985212532
         },
         {
-            u"name": u"RDS processes",
-            u"cpuUsedPc": 1.52,
-            u"memUsedPc": 20.61,
-            u"workingSetKb": 367720,
-            u"workingSetPrivKb": 215996,
-            u"workingSetShareableKb": 151724,
-            u"virtKb": 4331792332
+            "name": "RDS processes",
+            "cpuUsedPc": 1.52,
+            "memUsedPc": 20.61,
+            "workingSetKb": 367720,
+            "workingSetPrivKb": 215996,
+            "workingSetShareableKb": 151724,
+            "virtKb": 4331792332
         },
         {
-            u"name": u"sqlwriter.exe",
-            u"pid": 1736,
-            u"cpuUsedPc": 0,
-            u"memUsedPc": 0.1,
-            u"workingSetKb": 5876,
-            u"workingSetPrivKb": 1020,
-            u"workingSetShareableKb": 4856,
-            u"virtKb": 38280
+            "name": "sqlwriter.exe",
+            "pid": 1736,
+            "cpuUsedPc": 0,
+            "memUsedPc": 0.1,
+            "workingSetKb": 5876,
+            "workingSetPrivKb": 1020,
+            "workingSetShareableKb": 4856,
+            "virtKb": 38280
         },
         {
-            u"name": u"fdlauncher.exe",
-            u"pid": 2436,
-            u"cpuUsedPc": 0,
-            u"memUsedPc": 0.05,
-            u"workingSetKb": 3576,
-            u"workingSetPrivKb": 568,
-            u"workingSetShareableKb": 3008,
-            u"virtKb": 26776
+            "name": "fdlauncher.exe",
+            "pid": 2436,
+            "cpuUsedPc": 0,
+            "memUsedPc": 0.05,
+            "workingSetKb": 3576,
+            "workingSetPrivKb": 568,
+            "workingSetShareableKb": 3008,
+            "virtKb": 26776
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"cpuUsedPc": 32.22,
-            u"memUsedPc": 11.12,
-            u"workingSetKb": 158676,
-            u"workingSetPrivKb": 116608,
-            u"workingSetShareableKb": 42068,
-            u"virtKb": 2694704
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "cpuUsedPc": 32.22,
+            "memUsedPc": 11.12,
+            "workingSetKb": 158676,
+            "workingSetPrivKb": 116608,
+            "workingSetShareableKb": 42068,
+            "virtKb": 2694704
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3628,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3628,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3636,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3636,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3644,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3644,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3648,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3648,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3660,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3660,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3664,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3664,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3668,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3668,
+            "cpuUsedPc": 0
         },
         {
-            u'name': u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3672,
-            u"cpuUsedPc": 32.22
+            'name': "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3672,
+            "cpuUsedPc": 32.22
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3676,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3676,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3680,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3680,
+            "cpuUsedPc": 0
         },
     ]
 }
 
 # Sample RDSOS output for an Aurora instance
 aurora_dict = {
-    u"engine": u"Aurora",
-    u"instanceID": u"trevor",
-    u"instanceResourceID": u"db-F3AZGY5JTAS65TT4E7U3CDS6AM",
-    u"timestamp": u"2017-09-12T23:02:53Z",
-    u"version": 1,
-    u"uptime": u"0:44:23",
-    u"numVCPUs": 1,
-    u"cpuUtilization": {
-        u"guest": 0,
-        u"irq": 0.04,
-        u"system": 1.86,
-        u"wait": 2.61,
-        u"idle": 90.08,
-        u"user": 5.01,
-        u"total": 9.92,
-        u"steal": 0.36,
-        u"nice": 0.04
+    "engine": "Aurora",
+    "instanceID": "trevor",
+    "instanceResourceID": "db-F3AZGY5JTAS65TT4E7U3CDS6AM",
+    "timestamp": "2017-09-12T23:02:53Z",
+    "version": 1,
+    "uptime": "0:44:23",
+    "numVCPUs": 1,
+    "cpuUtilization": {
+        "guest": 0,
+        "irq": 0.04,
+        "system": 1.86,
+        "wait": 2.61,
+        "idle": 90.08,
+        "user": 5.01,
+        "total": 9.92,
+        "steal": 0.36,
+        "nice": 0.04
     },
-    u"loadAverageMinute": {
-        u"fifteen": 0.13,
-        u"five": 0.1,
-        u"one": 0.3
+    "loadAverageMinute": {
+        "fifteen": 0.13,
+        "five": 0.1,
+        "one": 0.3
     },
-    u"memory": {
-        u"writeback": 0,
-        u"hugePagesFree": 1024,
-        u"hugePagesRsvd": 0,
-        u"hugePagesSurp": 0,
-        u"cached": 489508,
-        u"hugePagesSize": 2048,
-        u"free": 99192,
-        u"hugePagesTotal": 367616,
-        u"inactive": 260216,
-        u"pageTables": 6244,
-        u"dirty": 1400,
-        u"mapped": 84816,
-        u"active": 890436,
-        u"total": 2052380,
-        u"slab": 38916,
-        u"buffers": 67024
+    "memory": {
+        "writeback": 0,
+        "hugePagesFree": 1024,
+        "hugePagesRsvd": 0,
+        "hugePagesSurp": 0,
+        "cached": 489508,
+        "hugePagesSize": 2048,
+        "free": 99192,
+        "hugePagesTotal": 367616,
+        "inactive": 260216,
+        "pageTables": 6244,
+        "dirty": 1400,
+        "mapped": 84816,
+        "active": 890436,
+        "total": 2052380,
+        "slab": 38916,
+        "buffers": 67024
     },
-    u"tasks": {
-        u"sleeping": 233,
-        u"zombie": 0,
-        u"running": 2,
-        u"stopped": 0,
-        u"total": 235,
-        u"blocked": 0
+    "tasks": {
+        "sleeping": 233,
+        "zombie": 0,
+        "running": 2,
+        "stopped": 0,
+        "total": 235,
+        "blocked": 0
     },
-    u"swap": {
-        u"cached": 0,
-        u"total": 0,
-        u"free": 0
+    "swap": {
+        "cached": 0,
+        "total": 0,
+        "free": 0
     },
-    u"network": [
+    "network": [
         {
-            u"interface": u"eth0",
-            u"rx": 58724202.3,
-            u"tx": 2613197.9
+            "interface": "eth0",
+            "rx": 58724202.3,
+            "tx": 2613197.9
         }
     ],
-    u"diskIO": [
+    "diskIO": [
         {
-            u"readLatency": 2.74,
-            u"writeLatency": 1.5,
-            u"writeThroughput": 476409.8,
-            u"readThroughput": 665190.4,
-            u"readIOsPS": 40.6,
-            u"diskQueueDepth": 0,
-            u"writeIOsPS": 1426.8
+            "readLatency": 2.74,
+            "writeLatency": 1.5,
+            "writeThroughput": 476409.8,
+            "readThroughput": 665190.4,
+            "readIOsPS": 40.6,
+            "diskQueueDepth": 0,
+            "writeIOsPS": 1426.8
         }
     ],
-    u"fileSys": [
+    "fileSys": [
         {
-            u"used": 68956,
-            u"name": u"rdsfilesys",
-            u"usedFiles": 211,
-            u"usedFilePercent": 0.01,
-            u"maxFiles": 2097152,
-            u"mountPoint": u"/rdsdbdata",
-            u"total": 32890736,
-            u"usedPercent": 0.21
+            "used": 68956,
+            "name": "rdsfilesys",
+            "usedFiles": 211,
+            "usedFilePercent": 0.01,
+            "maxFiles": 2097152,
+            "mountPoint": "/rdsdbdata",
+            "total": 32890736,
+            "usedPercent": 0.21
         }
     ],
-    u"processList": [
+    "processList": [
         {
-            u"vss": 1232180,
-            u"name": u"aurora",
-            u"tgid": 5439,
-            u"vmlimit": 2052380,
-            u"parentID": 1,
-            u"memoryUsedPc": 12.47,
-            u"cpuUsedPc": 0,
-            u"id": 5439,
-            u"rss": 255908
+            "vss": 1232180,
+            "name": "aurora",
+            "tgid": 5439,
+            "vmlimit": 2052380,
+            "parentID": 1,
+            "memoryUsedPc": 12.47,
+            "cpuUsedPc": 0,
+            "id": 5439,
+            "rss": 255908
         },
         {
-            u"vss": 691648,
-            u"name": u"OS processes",
-            u"tgid": 0,
-            u"vmlimit": u"",
-            u"parentID": 0,
-            u"memoryUsedPc": 1.15,
-            u"cpuUsedPc": 0,
-            u"id": 0,
-            u"rss": 23888
+            "vss": 691648,
+            "name": "OS processes",
+            "tgid": 0,
+            "vmlimit": "",
+            "parentID": 0,
+            "memoryUsedPc": 1.15,
+            "cpuUsedPc": 0,
+            "id": 0,
+            "rss": 23888
         },
         {
-            u"vss": 3247344,
-            u"name": u"RDS processes",
-            u"tgid": 0,
-            u"vmlimit": u"",
-            u"parentID": 0,
-            u"memoryUsedPc": 20.91,
-            u"cpuUsedPc": 0,
-            u"id": 0,
-            u"rss": 429908
+            "vss": 3247344,
+            "name": "RDS processes",
+            "tgid": 0,
+            "vmlimit": "",
+            "parentID": 0,
+            "memoryUsedPc": 20.91,
+            "cpuUsedPc": 0,
+            "id": 0,
+            "rss": 429908
         }
     ]
 }

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1,6 +1,10 @@
+import os
 import unittest
 from sample_input import my_sql_dict, sql_server_dict, aurora_dict
 from enhanced_rds.lambda_script import e, pull_metric_names, parse_logs
+
+
+os.environ['groups'] = 'All'
 
 
 class TestLambdaComponents(unittest.TestCase):

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -130,11 +130,11 @@ class TestLambdaComponents(unittest.TestCase):
             if metric_name in checklist:
                 entry_dict[metric_name] = entry
 
-            if len(entry_dict.keys()) == len(checklist):
+            if len(list(entry_dict.keys())) == len(checklist):
                 return entry_dict
 
     def test_standard_parsing(self):
-        desired_metrics_info = pull_metric_names(e(my_sql_dict[u'engine']))
+        desired_metrics_info = pull_metric_names(e(my_sql_dict['engine']))
         metric_entries = parse_logs(
             '1',
             'arn:aws:lambda:us-east-1:946288580872:function:testRDSLambda',
@@ -222,7 +222,7 @@ class TestLambdaComponents(unittest.TestCase):
         )
 
     def test_sql_server_parsing(self):
-        desired_metrics_info = pull_metric_names(e(sql_server_dict[u'engine']))
+        desired_metrics_info = pull_metric_names(e(sql_server_dict['engine']))
         metric_entries = parse_logs(
             '1',
             'arn:aws:lambda:us-west-2:845296:function:testSqlServer',
@@ -298,7 +298,7 @@ class TestLambdaComponents(unittest.TestCase):
         )
 
     def test_aurora_parsing(self):
-        desired_metrics_info = pull_metric_names(e(aurora_dict[u'engine']))
+        desired_metrics_info = pull_metric_names(e(aurora_dict['engine']))
         metric_entries = parse_logs(
             '1234',
             'arn:aws:lambda:eu-west-1:098712340987:function:testAurora',
@@ -366,7 +366,7 @@ class TestLambdaComponents(unittest.TestCase):
             'Incorrect diskIO.writeThroughput'
         )
         self.assertEqual(
-            len(diskio_write_throughput['dimensions'].keys()),
+            len(list(diskio_write_throughput['dimensions'].keys())),
             4,
             'Incorrectly parsed diskIO metrics'
         )

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from sample_input import my_sql_dict, sql_server_dict, aurora_dict
-from enhanced_rds.lambda_script import e, pull_metric_names, parse_logs
+from enhanced_rds.lambda_script import pull_metric_names, parse_logs
 
 
 os.environ['groups'] = 'All'
@@ -138,7 +138,7 @@ class TestLambdaComponents(unittest.TestCase):
                 return entry_dict
 
     def test_standard_parsing(self):
-        desired_metrics_info = pull_metric_names(e(my_sql_dict['engine']))
+        desired_metrics_info = pull_metric_names(my_sql_dict['engine'])
         metric_entries = parse_logs(
             '1',
             'arn:aws:lambda:us-east-1:946288580872:function:testRDSLambda',
@@ -226,7 +226,7 @@ class TestLambdaComponents(unittest.TestCase):
         )
 
     def test_sql_server_parsing(self):
-        desired_metrics_info = pull_metric_names(e(sql_server_dict['engine']))
+        desired_metrics_info = pull_metric_names(sql_server_dict['engine'])
         metric_entries = parse_logs(
             '1',
             'arn:aws:lambda:us-west-2:845296:function:testSqlServer',
@@ -302,7 +302,7 @@ class TestLambdaComponents(unittest.TestCase):
         )
 
     def test_aurora_parsing(self):
-        desired_metrics_info = pull_metric_names(e(aurora_dict['engine']))
+        desired_metrics_info = pull_metric_names(aurora_dict['engine'])
         metric_entries = parse_logs(
             '1234',
             'arn:aws:lambda:eu-west-1:098712340987:function:testAurora',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, flake8
+envlist = py36, py37, py38, flake8
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, flake8
+envlist = py37, flake8
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Update code to Python3, breaking Python2 compatibility. 
Changes:
* Basic syntax
* Unicode casts (Python3 uses unicode for strings)
* Fix missing boto3 import
* Fix missing `groups` environment variables for Tox (https://github.com/signalfx/enhanced-rds-monitoring/issues/8)
* Some other minor changes

Tox succeeds on py36, py37, and py38.