### PR TITLE
Upgrade to python 3.7, make unit tests run and fix a bug 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 /build/
 /enhanced_rds.zip
 /*.egg-info
+
+# script to test locally
+tests/local.py

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Before you begin, you must enable the Enhanced Monitoring option for the RDS ins
 * [Building from source](#building-from-source)
 * [Metrics collected by this integration](#metric-groups-collected-by-this-integration)
 
+#### Note: Upgrading from version 0.1.0 (Python 2.7) to version 0.2.0 (Python 3.x)
+Please note that the new version requires AWS lambda handler to be set to `enhanced_rds.lambda_script.lambda_handler`.
+
 #### Note: Encryption of your SignalFx access token
 This Lambda function uses your SignalFx access token to send metrics to SignalFx, as an environment variable to the function. While Lambda encrypts all environment variables at rest and decrypts them upon invocation, AWS recommends that all sensitive information such as access tokens be encrypted using a KMS key before function deployment, and decrypted at runtime within the code. 
 
@@ -125,7 +128,7 @@ Add.
 #### Function code
 Once the function is created you can change the configurations. Upload the ZIP
 file containing the deployment package. Change the text in `Handler` to be
-`lambda_script.lambda_handler`.
+`enhanced_rds.lambda_script.lambda_handler`.
 
 #### Environment variables
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-
-# Copyright (C) 2017 SignalFx, Inc. All rights reserved.
+# Copyright (C) 2017-2018 SignalFx, Inc. All rights reserved.
+# Copyright (C) 2019-2020 Splunk, Inc. All rights reserved.
 
 # Builds the deployable ZIP file for the AWS Lambda function, with all of its
 # dependencies.
@@ -34,10 +34,11 @@ prefix=
 EOF
 
 # Install dependencies
-pip install -r ../requirements.txt --upgrade -t .
+pip3 install -r ../requirements.txt --upgrade -t .
 
 # Package everything up (all dependencies and lambda function code) into the
-# same ZIP archive.
+# same ZIP archive. Make sure to put code in enhanced_rds directory inside zip file, so that all the imports work in Lambda.
+
 zip ../$TARGET -r *
-cd ../$NAME
-zip -u ../$TARGET *.py
+cd ..
+zip -u ./$TARGET $NAME/*.py

--- a/enhanced_rds/metric_maps.py
+++ b/enhanced_rds/metric_maps.py
@@ -6,59 +6,59 @@
 
 # Standard set of metric info
 METRICS = [
-    u'cpuUtilization',
-    u'diskIO',
-    u'fileSys',
-    u'loadAverageMinute',
-    u'memory',
-    u'network',
-    u'swap',
-    u'tasks',
-    u'OSprocesses',
-    u'RDSprocesses'
+    'cpuUtilization',
+    'diskIO',
+    'fileSys',
+    'loadAverageMinute',
+    'memory',
+    'network',
+    'swap',
+    'tasks',
+    'OSprocesses',
+    'RDSprocesses'
 ]
 
 PROCESS_METRICS = [
-    u'vss',
-    u'rss',
-    u'memoryUsedPc',
-    u'cpuUsedPc'
+    'vss',
+    'rss',
+    'memoryUsedPc',
+    'cpuUsedPc'
 ]
 
 METRICS_DIMS = {
-    u'diskIO': [u'device'],
-    u'fileSys': [u'name', u'mountPoint'],
-    u'network': [u'interface']
+    'diskIO': ['device'],
+    'fileSys': ['name', 'mountPoint'],
+    'network': ['interface']
 }
 
 # Metric info for Aurora instances.
 METRICS_AURORA_DIMS = {
-    u'diskIO': [],  # Workaround to account for Aurora diskIO metrics
-    u'fileSys': [u'name', u'mountPoint'],
-    u'network': [u'interface']
+    'diskIO': [],  # Workaround to account for Aurora diskIO metrics
+    'fileSys': ['name', 'mountPoint'],
+    'network': ['interface']
 }
 
 # Metric info for Microsoft SQL instances.
 METRICS_MICROSOFT = [
-    u'cpuUtilization',
-    u'disks',
-    u'memory',
-    u'network',
-    u'OSprocesses',
-    u'RDSprocesses',
-    u'system'
+    'cpuUtilization',
+    'disks',
+    'memory',
+    'network',
+    'OSprocesses',
+    'RDSprocesses',
+    'system'
 ]
 
 PROCESS_METRICS_MICROSOFT = [
-    u'cpuUsedPc',
-    u'memUsedPc',
-    u'workingSetKb',
-    u'workingSetPrivKb',
-    u'workingSetShareableKb',
-    u'virtKb'
+    'cpuUsedPc',
+    'memUsedPc',
+    'workingSetKb',
+    'workingSetPrivKb',
+    'workingSetShareableKb',
+    'virtKb'
 ]
 
 METRICS_MICROSOFT_DIMS = {
-    u'disks': [u'name'],
-    u'network': [u'interface']
+    'disks': ['name'],
+    'network': ['interface']
 }

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 
@@ -7,7 +7,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='enhanced_rds',
-    version='0.1.0',
+    version='0.2.0',
     description='AWS Lambda function wrapper to capture metrics from enhanced RDS monitoring logs',
     zip_safe=True,
     packages=find_packages(),

--- a/tests/sample_input.py
+++ b/tests/sample_input.py
@@ -1,504 +1,504 @@
 # Sample RDSOS output from a MySQL instance
 my_sql_dict = {
-    u"engine": u"MYSQL",
-    u"instanceID": u"ppr9b9oge80i99",
-    u"instanceResourceID": u"db-H4UK4SA7E62QPMAYTMPK5XWETQ",
-    u"timestamp": u"2017-09-19T00:21:07Z",
-    u"version": 1,
-    u"uptime": u"272 days, 1:28:18",
-    u"numVCPUs": 2,
-    u"cpuUtilization": {
-        u"guest": 0,
-        u"irq": 0.72,
-        u"system": 7.25,
-        u"wait": 4.35,
-        u"idle": 78.99,
-        u"user": 3.62,
-        u"total": 21.01,
-        u"steal": 1.45,
-        u"nice": 3.62
+    "engine": "MYSQL",
+    "instanceID": "ppr9b9oge80i99",
+    "instanceResourceID": "db-H4UK4SA7E62QPMAYTMPK5XWETQ",
+    "timestamp": "2017-09-19T00:21:07Z",
+    "version": 1,
+    "uptime": "272 days, 1:28:18",
+    "numVCPUs": 2,
+    "cpuUtilization": {
+        "guest": 0,
+        "irq": 0.72,
+        "system": 7.25,
+        "wait": 4.35,
+        "idle": 78.99,
+        "user": 3.62,
+        "total": 21.01,
+        "steal": 1.45,
+        "nice": 3.62
     },
-    u"loadAverageMinute": {
-        u"fifteen": 0.4,
-        u"five": 0.3,
-        u"one": 0.29
+    "loadAverageMinute": {
+        "fifteen": 0.4,
+        "five": 0.3,
+        "one": 0.29
     },
-    u"memory": {
-        u"writeback": 0,
-        u"hugePagesFree": 0,
-        u"hugePagesRsvd": 0,
-        u"hugePagesSurp": 0,
-        u"cached": 3288068,
-        u"hugePagesSize": 2048,
-        u"free": 2746028,
-        u"hugePagesTotal": 0,
-        u"inactive": 838368,
-        u"pageTables": 5448,
-        u"dirty": 144,
-        u"mapped": 25548,
-        u"active": 3766972,
-        u"total": 7697596,
-        u"slab": 239772,
-        u"buffers": 301616
+    "memory": {
+        "writeback": 0,
+        "hugePagesFree": 0,
+        "hugePagesRsvd": 0,
+        "hugePagesSurp": 0,
+        "cached": 3288068,
+        "hugePagesSize": 2048,
+        "free": 2746028,
+        "hugePagesTotal": 0,
+        "inactive": 838368,
+        "pageTables": 5448,
+        "dirty": 144,
+        "mapped": 25548,
+        "active": 3766972,
+        "total": 7697596,
+        "slab": 239772,
+        "buffers": 301616
     },
-    u"tasks": {
-        u"sleeping": 256,
-        u"zombie": 0,
-        u"running": 4,
-        u"stopped": 0,
-        u"total": 262,
-        u"blocked": 2
+    "tasks": {
+        "sleeping": 256,
+        "zombie": 0,
+        "running": 4,
+        "stopped": 0,
+        "total": 262,
+        "blocked": 2
     },
-    u"swap": {
-        u"cached": 0,
-        u"total": 7703160,
-        u"free": 7703160
+    "swap": {
+        "cached": 0,
+        "total": 7703160,
+        "free": 7703160
     },
-    u"network": [
+    "network": [
         {
-            u"interface": u"eth0",
-            u"rx": 821640,
-            u"tx": 2856222
+            "interface": "eth0",
+            "rx": 821640,
+            "tx": 2856222
         }
     ],
-    u"diskIO": [
+    "diskIO": [
         {
-            u"writeKbPS": 20,
-            u"readIOsPS": 0,
-            u"await": 1.6,
-            u"readKbPS": 0,
-            u"rrqmPS": 0,
-            u"util": 0.8,
-            u"avgQueueLen": 0.01,
-            u"tps": 5,
-            u"readKb": 0,
-            u"device": u"rdsdev",
-            u"writeKb": 20,
-            u"avgReqSz": 4,
-            u"wrqmPS": 0,
-            u"writeIOsPS": 5
+            "writeKbPS": 20,
+            "readIOsPS": 0,
+            "await": 1.6,
+            "readKbPS": 0,
+            "rrqmPS": 0,
+            "util": 0.8,
+            "avgQueueLen": 0.01,
+            "tps": 5,
+            "readKb": 0,
+            "device": "rdsdev",
+            "writeKb": 20,
+            "avgReqSz": 4,
+            "wrqmPS": 0,
+            "writeIOsPS": 5
         }
     ],
-    u"fileSys": [
+    "fileSys": [
         {
-            u"used": 626316,
-            u"name": u"rdsfilesys",
-            u"usedFiles": 523,
-            u"usedFilePercent": 0.01,
-            u"maxFiles": 6553600,
-            u"mountPoint": u"/rdsdbdata",
-            u"total": 103053476,
-            u"usedPercent": 0.61
+            "used": 626316,
+            "name": "rdsfilesys",
+            "usedFiles": 523,
+            "usedFilePercent": 0.01,
+            "maxFiles": 6553600,
+            "mountPoint": "/rdsdbdata",
+            "total": 103053476,
+            "usedPercent": 0.61
         }
     ],
-    u"processList": [
+    "processList": [
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 765,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 765,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 766,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 766,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 780,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 780,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 781,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 781,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 0,
-            u"id": 3305,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 0,
+            "id": 3305,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 6,
-            u"id": 4111,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 6,
+            "id": 4111,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 10888,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 10888,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 6,
-            u"id": 19825,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 6,
+            "id": 19825,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 31951,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 31951,
+            "rss": 703620
         },
         {
-            u"vss": 6365136,
-            u"name": u"mysqld",
-            u"tgid": 3305,
-            u"parentID": 1,
-            u"memoryUsedPc": 9.14,
-            u"cpuUsedPc": 5.5,
-            u"id": 32015,
-            u"rss": 703620
+            "vss": 6365136,
+            "name": "mysqld",
+            "tgid": 3305,
+            "parentID": 1,
+            "memoryUsedPc": 9.14,
+            "cpuUsedPc": 5.5,
+            "id": 32015,
+            "rss": 703620
         },
         {
-            u"vss": 935380,
-            u"name": u"OS processes",
-            u"tgid": 0,
-            u"parentID": 0,
-            u"memoryUsedPc": 0.35,
-            u"cpuUsedPc": 0.5,
-            u"id": 0,
-            u"rss": 27824
+            "vss": 935380,
+            "name": "OS processes",
+            "tgid": 0,
+            "parentID": 0,
+            "memoryUsedPc": 0.35,
+            "cpuUsedPc": 0.5,
+            "id": 0,
+            "rss": 27824
         },
         {
-            u"vss": 1293204,
-            u"name": u"RDS processes",
-            u"tgid": 0,
-            u"parentID": 0,
-            u"memoryUsedPc": 4.27,
-            u"cpuUsedPc": 4,
-            u"id": 0,
-            u"rss": 329184
+            "vss": 1293204,
+            "name": "RDS processes",
+            "tgid": 0,
+            "parentID": 0,
+            "memoryUsedPc": 4.27,
+            "cpuUsedPc": 4,
+            "id": 0,
+            "rss": 329184
         }
     ]
 }
 
 # Sample RDSOS output from a SQL Server instance
 sql_server_dict = {
-    u"engine": u"SqlServer",
-    u"instanceID": u"trevor",
-    u"instanceResourceID": u"db-YWCA2G6UQEA3NYZ54IS6XEBGUE",
-    u"timestamp": u"2017-09-12T23:58:59Z",
-    u"version": 1,
-    u"uptime": u"0 days, 00:10:43",
-    u"numVCPUs": 1,
-    u"cpuUtilization": {
-        u"idle": 64.13,
-        u"kern": 11.85,
-        u"user": 24.01
+    "engine": "SqlServer",
+    "instanceID": "trevor",
+    "instanceResourceID": "db-YWCA2G6UQEA3NYZ54IS6XEBGUE",
+    "timestamp": "2017-09-12T23:58:59Z",
+    "version": 1,
+    "uptime": "0 days, 00:10:43",
+    "numVCPUs": 1,
+    "cpuUtilization": {
+        "idle": 64.13,
+        "kern": 11.85,
+        "user": 24.01
     },
-    u"memory": {
-        u"commitTotKb": 1073308,
-        u"commitLimitKb": 1572464,
-        u"commitPeakKb": 1109112,
-        u"physTotKb": 1048176,
-        u"physAvailKb": 125072,
-        u"sysCacheKb": 182448,
-        u"kernTotKb": 192596,
-        u"kernPagedKb": 136120,
-        u"kernNonpagedKb": 56476,
-        u"sqlServerTotKb": 123432,
-        u"pageSize": 4096
+    "memory": {
+        "commitTotKb": 1073308,
+        "commitLimitKb": 1572464,
+        "commitPeakKb": 1109112,
+        "physTotKb": 1048176,
+        "physAvailKb": 125072,
+        "sysCacheKb": 182448,
+        "kernTotKb": 192596,
+        "kernPagedKb": 136120,
+        "kernNonpagedKb": 56476,
+        "sqlServerTotKb": 123432,
+        "pageSize": 4096
     },
-    u"system": {
-        u"handles": 14874,
-        u"threads": 634,
-        u"processes": 44
+    "system": {
+        "handles": 14874,
+        "threads": 634,
+        "processes": 44
     },
-    u"disks": [
+    "disks": [
         {
-            u"name": u"rdsdbdata",
-            u"totalKb": 20838336,
-            u"usedKb": 162752,
-            u"usedPc": 0.78,
-            u"availKb": 20675584,
-            u"availPc": 99.22,
-            u"rdCountPS": 0,
-            u"rdBytesPS": 0,
-            u"wrCountPS": 0,
-            u"wrBytesPS": 0
+            "name": "rdsdbdata",
+            "totalKb": 20838336,
+            "usedKb": 162752,
+            "usedPc": 0.78,
+            "availKb": 20675584,
+            "availPc": 99.22,
+            "rdCountPS": 0,
+            "rdBytesPS": 0,
+            "wrCountPS": 0,
+            "wrBytesPS": 0
         }
     ],
-    u"network": [
+    "network": [
         {
-            u"interface": "Ethernet 2",
-            u"rdBytesPS": 0,
-            u"wrBytesPS": 0
+            "interface": "Ethernet 2",
+            "rdBytesPS": 0,
+            "wrBytesPS": 0
         }
     ],
-    u"processList": [
+    "processList": [
         {
-            u"name": u"OS processes",
-            u"cpuUsedPc": 0.3,
-            u"memUsedPc": 8.46,
-            u"workingSetKb": 249908,
-            u"workingSetPrivKb": 88728,
-            u"workingSetShareableKb": 161180,
-            u"virtKb": 57985212532
+            "name": "OS processes",
+            "cpuUsedPc": 0.3,
+            "memUsedPc": 8.46,
+            "workingSetKb": 249908,
+            "workingSetPrivKb": 88728,
+            "workingSetShareableKb": 161180,
+            "virtKb": 57985212532
         },
         {
-            u"name": u"RDS processes",
-            u"cpuUsedPc": 1.52,
-            u"memUsedPc": 20.61,
-            u"workingSetKb": 367720,
-            u"workingSetPrivKb": 215996,
-            u"workingSetShareableKb": 151724,
-            u"virtKb": 4331792332
+            "name": "RDS processes",
+            "cpuUsedPc": 1.52,
+            "memUsedPc": 20.61,
+            "workingSetKb": 367720,
+            "workingSetPrivKb": 215996,
+            "workingSetShareableKb": 151724,
+            "virtKb": 4331792332
         },
         {
-            u"name": u"sqlwriter.exe",
-            u"pid": 1736,
-            u"cpuUsedPc": 0,
-            u"memUsedPc": 0.1,
-            u"workingSetKb": 5876,
-            u"workingSetPrivKb": 1020,
-            u"workingSetShareableKb": 4856,
-            u"virtKb": 38280
+            "name": "sqlwriter.exe",
+            "pid": 1736,
+            "cpuUsedPc": 0,
+            "memUsedPc": 0.1,
+            "workingSetKb": 5876,
+            "workingSetPrivKb": 1020,
+            "workingSetShareableKb": 4856,
+            "virtKb": 38280
         },
         {
-            u"name": u"fdlauncher.exe",
-            u"pid": 2436,
-            u"cpuUsedPc": 0,
-            u"memUsedPc": 0.05,
-            u"workingSetKb": 3576,
-            u"workingSetPrivKb": 568,
-            u"workingSetShareableKb": 3008,
-            u"virtKb": 26776
+            "name": "fdlauncher.exe",
+            "pid": 2436,
+            "cpuUsedPc": 0,
+            "memUsedPc": 0.05,
+            "workingSetKb": 3576,
+            "workingSetPrivKb": 568,
+            "workingSetShareableKb": 3008,
+            "virtKb": 26776
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"cpuUsedPc": 32.22,
-            u"memUsedPc": 11.12,
-            u"workingSetKb": 158676,
-            u"workingSetPrivKb": 116608,
-            u"workingSetShareableKb": 42068,
-            u"virtKb": 2694704
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "cpuUsedPc": 32.22,
+            "memUsedPc": 11.12,
+            "workingSetKb": 158676,
+            "workingSetPrivKb": 116608,
+            "workingSetShareableKb": 42068,
+            "virtKb": 2694704
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3628,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3628,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3636,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3636,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3644,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3644,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3648,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3648,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3660,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3660,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3664,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3664,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3668,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3668,
+            "cpuUsedPc": 0
         },
         {
-            u'name': u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3672,
-            u"cpuUsedPc": 32.22
+            u'name': "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3672,
+            "cpuUsedPc": 32.22
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3676,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3676,
+            "cpuUsedPc": 0
         },
         {
-            u"name": u"sqlservr.exe",
-            u"pid": 3624,
-            u"tid": 3680,
-            u"cpuUsedPc": 0
+            "name": "sqlservr.exe",
+            "pid": 3624,
+            "tid": 3680,
+            "cpuUsedPc": 0
         },
     ]
 }
 
 # Sample RDSOS output for an Aurora instance
 aurora_dict = {
-    u"engine": u"Aurora",
-    u"instanceID": u"trevor",
-    u"instanceResourceID": u"db-F3AZGY5JTAS65TT4E7U3CDS6AM",
-    u"timestamp": u"2017-09-12T23:02:53Z",
-    u"version": 1,
-    u"uptime": u"0:44:23",
-    u"numVCPUs": 1,
-    u"cpuUtilization": {
-        u"guest": 0,
-        u"irq": 0.04,
-        u"system": 1.86,
-        u"wait": 2.61,
-        u"idle": 90.08,
-        u"user": 5.01,
-        u"total": 9.92,
-        u"steal": 0.36,
-        u"nice": 0.04
+    "engine": "Aurora",
+    "instanceID": "trevor",
+    "instanceResourceID": "db-F3AZGY5JTAS65TT4E7U3CDS6AM",
+    "timestamp": "2017-09-12T23:02:53Z",
+    "version": 1,
+    "uptime": "0:44:23",
+    "numVCPUs": 1,
+    "cpuUtilization": {
+        "guest": 0,
+        "irq": 0.04,
+        "system": 1.86,
+        "wait": 2.61,
+        "idle": 90.08,
+        "user": 5.01,
+        "total": 9.92,
+        "steal": 0.36,
+        "nice": 0.04
     },
-    u"loadAverageMinute": {
-        u"fifteen": 0.13,
-        u"five": 0.1,
-        u"one": 0.3
+    "loadAverageMinute": {
+        "fifteen": 0.13,
+        "five": 0.1,
+        "one": 0.3
     },
-    u"memory": {
-        u"writeback": 0,
-        u"hugePagesFree": 1024,
-        u"hugePagesRsvd": 0,
-        u"hugePagesSurp": 0,
-        u"cached": 489508,
-        u"hugePagesSize": 2048,
-        u"free": 99192,
-        u"hugePagesTotal": 367616,
-        u"inactive": 260216,
-        u"pageTables": 6244,
-        u"dirty": 1400,
-        u"mapped": 84816,
-        u"active": 890436,
-        u"total": 2052380,
-        u"slab": 38916,
-        u"buffers": 67024
+    "memory": {
+        "writeback": 0,
+        "hugePagesFree": 1024,
+        "hugePagesRsvd": 0,
+        "hugePagesSurp": 0,
+        "cached": 489508,
+        "hugePagesSize": 2048,
+        "free": 99192,
+        "hugePagesTotal": 367616,
+        "inactive": 260216,
+        "pageTables": 6244,
+        "dirty": 1400,
+        "mapped": 84816,
+        "active": 890436,
+        "total": 2052380,
+        "slab": 38916,
+        "buffers": 67024
     },
-    u"tasks": {
-        u"sleeping": 233,
-        u"zombie": 0,
-        u"running": 2,
-        u"stopped": 0,
-        u"total": 235,
-        u"blocked": 0
+    "tasks": {
+        "sleeping": 233,
+        "zombie": 0,
+        "running": 2,
+        "stopped": 0,
+        "total": 235,
+        "blocked": 0
     },
-    u"swap": {
-        u"cached": 0,
-        u"total": 0,
-        u"free": 0
+    "swap": {
+        "cached": 0,
+        "total": 0,
+        "free": 0
     },
-    u"network": [
+    "network": [
         {
-            u"interface": u"eth0",
-            u"rx": 58724202.3,
-            u"tx": 2613197.9
+            "interface": "eth0",
+            "rx": 58724202.3,
+            "tx": 2613197.9
         }
     ],
-    u"diskIO": [
+    "diskIO": [
         {
-            u"readLatency": 2.74,
-            u"writeLatency": 1.5,
-            u"writeThroughput": 476409.8,
-            u"readThroughput": 665190.4,
-            u"readIOsPS": 40.6,
-            u"diskQueueDepth": 0,
-            u"writeIOsPS": 1426.8
+            "readLatency": 2.74,
+            "writeLatency": 1.5,
+            "writeThroughput": 476409.8,
+            "readThroughput": 665190.4,
+            "readIOsPS": 40.6,
+            "diskQueueDepth": 0,
+            "writeIOsPS": 1426.8
         }
     ],
-    u"fileSys": [
+    "fileSys": [
         {
-            u"used": 68956,
-            u"name": u"rdsfilesys",
-            u"usedFiles": 211,
-            u"usedFilePercent": 0.01,
-            u"maxFiles": 2097152,
-            u"mountPoint": u"/rdsdbdata",
-            u"total": 32890736,
-            u"usedPercent": 0.21
+            "used": 68956,
+            "name": "rdsfilesys",
+            "usedFiles": 211,
+            "usedFilePercent": 0.01,
+            "maxFiles": 2097152,
+            "mountPoint": "/rdsdbdata",
+            "total": 32890736,
+            "usedPercent": 0.21
         }
     ],
-    u"processList": [
+    "processList": [
         {
-            u"vss": 1232180,
-            u"name": u"aurora",
-            u"tgid": 5439,
-            u"vmlimit": 2052380,
-            u"parentID": 1,
-            u"memoryUsedPc": 12.47,
-            u"cpuUsedPc": 0,
-            u"id": 5439,
-            u"rss": 255908
+            "vss": 1232180,
+            "name": "aurora",
+            "tgid": 5439,
+            "vmlimit": 2052380,
+            "parentID": 1,
+            "memoryUsedPc": 12.47,
+            "cpuUsedPc": 0,
+            "id": 5439,
+            "rss": 255908
         },
         {
-            u"vss": 691648,
-            u"name": u"OS processes",
-            u"tgid": 0,
-            u"vmlimit": u"",
-            u"parentID": 0,
-            u"memoryUsedPc": 1.15,
-            u"cpuUsedPc": 0,
-            u"id": 0,
-            u"rss": 23888
+            "vss": 691648,
+            "name": "OS processes",
+            "tgid": 0,
+            "vmlimit": "",
+            "parentID": 0,
+            "memoryUsedPc": 1.15,
+            "cpuUsedPc": 0,
+            "id": 0,
+            "rss": 23888
         },
         {
-            u"vss": 3247344,
-            u"name": u"RDS processes",
-            u"tgid": 0,
-            u"vmlimit": u"",
-            u"parentID": 0,
-            u"memoryUsedPc": 20.91,
-            u"cpuUsedPc": 0,
-            u"id": 0,
-            u"rss": 429908
+            "vss": 3247344,
+            "name": "RDS processes",
+            "tgid": 0,
+            "vmlimit": "",
+            "parentID": 0,
+            "memoryUsedPc": 20.91,
+            "cpuUsedPc": 0,
+            "id": 0,
+            "rss": 429908
         }
     ]
 }

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1,6 +1,6 @@
 import unittest
 from sample_input import my_sql_dict, sql_server_dict, aurora_dict
-from enhanced_rds.lambda_script import e, pull_metric_names, parse_logs
+from enhanced_rds.lambda_script import pull_metric_names, parse_logs
 
 
 class TestLambdaComponents(unittest.TestCase):
@@ -134,7 +134,7 @@ class TestLambdaComponents(unittest.TestCase):
                 return entry_dict
 
     def test_standard_parsing(self):
-        desired_metrics_info = pull_metric_names(e(my_sql_dict[u'engine']))
+        desired_metrics_info = pull_metric_names(my_sql_dict['engine'])
         metric_entries = parse_logs(
             '1',
             'arn:aws:lambda:us-east-1:946288580872:function:testRDSLambda',
@@ -222,7 +222,7 @@ class TestLambdaComponents(unittest.TestCase):
         )
 
     def test_sql_server_parsing(self):
-        desired_metrics_info = pull_metric_names(e(sql_server_dict[u'engine']))
+        desired_metrics_info = pull_metric_names(sql_server_dict['engine'])
         metric_entries = parse_logs(
             '1',
             'arn:aws:lambda:us-west-2:845296:function:testSqlServer',
@@ -298,7 +298,7 @@ class TestLambdaComponents(unittest.TestCase):
         )
 
     def test_aurora_parsing(self):
-        desired_metrics_info = pull_metric_names(e(aurora_dict[u'engine']))
+        desired_metrics_info = pull_metric_names(aurora_dict['engine'])
         metric_entries = parse_logs(
             '1234',
             'arn:aws:lambda:eu-west-1:098712340987:function:testAurora',

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
-envlist = py27, flake8
+envlist = py37, py38, flake8
 skip_missing_interpreters = true
 
 [testenv]
 usedevelop = True
+setenv = groups = All
 commands = {envpython} tests/unittests.py
-deps = -r{toxinidir}/requirements.txt
+deps =
+    -r{toxinidir}/requirements.txt
+    boto3
+# boto3 is provided by lambda runtime and thus not in requirements.txt file
+
 
 [testenv:flake8]
 commands = flake8 enhanced_rds tests


### PR DESCRIPTION
 Changes: 
* use io instead of StringIO,
* remove unnecessary conversions to unicode,
* change the structure of zip for imports to work both in python 3.7 runtime and in tox tests
* add boto3 to tests requirements 
* change how we decide which db engine this is ("aurora-postresql" was not properly recognized, changed string equality to startswith)