### PR TITLE
Required changes to support imports both in lambda runtime and tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 /build/
 /enhanced_rds.zip
 /*.egg-info
+
+# script to test locally
+local.py

--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@ Before you begin, you must enable the Enhanced Monitoring option for the RDS ins
 * [Building from source](#building-from-source)
 * [Metrics collected by this integration](#metric-groups-collected-by-this-integration)
 
+#### Note: Upgrading from version 0.1.0 (Python 2.7) to version 0.2.0 (Python 3.x)
+Please note that the new version requires AWS lambda handler to be set to `enhanced_rds.lambda_script.lambda_handler`.
+
 #### Note: Encryption of your SignalFx access token
 This Lambda function uses your SignalFx access token to send metrics to SignalFx, as an environment variable to the function. While Lambda encrypts all environment variables at rest and decrypts them upon invocation, AWS recommends that all sensitive information such as access tokens be encrypted using a KMS key before function deployment, and decrypted at runtime within the code.
 
 Both procedures below include instructions for using either an encrypted or non-encrypted access token.
 
 ## Deploying through the Serverless Application Repository
+
+#### Note: Currently the latest version available in Serverless Application Repository is 0.1.0 (Python 2.7). For Python 3.x compatibility, please deploy from sources.
 
 ### 1. Set up an encryption key and encrypt your access token (if desired)
 Only follow this step if you chose to manually encrypt your access token.
@@ -125,7 +130,7 @@ Add.
 #### Function code
 Once the function is created you can change the configurations. Upload the ZIP
 file containing the deployment package. Change the text in `Handler` to be
-`lambda_script.lambda_handler`.
+`enhanced_rds.lambda_script.lambda_handler`.
 
 #### Environment variables
 

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-
-# Copyright (C) 2017 SignalFx, Inc. All rights reserved.
+# Copyright (C) 2017-2020 Splunk, Inc. All rights reserved.
 
 # Builds the deployable ZIP file for the AWS Lambda function, with all of its
 # dependencies.
@@ -34,10 +33,11 @@ prefix=
 EOF
 
 # Install dependencies
-pip install -r ../requirements.txt --upgrade -t .
+pip3 install -r ../requirements.txt --upgrade -t .
 
 # Package everything up (all dependencies and lambda function code) into the
-# same ZIP archive.
+# same ZIP archive. Make sure to put code in enhanced_rds directory inside zip file, so that all the imports work in Lambda.
+
 zip ../$TARGET -r *
-cd ../$NAME
-zip -u ../$TARGET *.py
+cd ..
+zip -u ./$TARGET $NAME/*.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-boto3
 signalfx

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from setuptools import setup, find_packages
 
@@ -7,7 +7,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='enhanced_rds',
-    version='0.1.0',
+    version='0.2.0',
     description='AWS Lambda function wrapper to capture metrics from enhanced RDS monitoring logs',
     zip_safe=True,
     packages=find_packages(),

--- a/tests/sample_input.py
+++ b/tests/sample_input.py
@@ -360,7 +360,7 @@ sql_server_dict = {
             "cpuUsedPc": 0
         },
         {
-            'name': "sqlservr.exe",
+            "name": "sqlservr.exe",
             "pid": 3624,
             "tid": 3672,
             "cpuUsedPc": 32.22

--- a/tests/unittests.py
+++ b/tests/unittests.py
@@ -1,10 +1,6 @@
-import os
 import unittest
 from sample_input import my_sql_dict, sql_server_dict, aurora_dict
 from enhanced_rds.lambda_script import pull_metric_names, parse_logs
-
-
-os.environ['groups'] = 'All'
 
 
 class TestLambdaComponents(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,13 @@ skip_missing_interpreters = true
 
 [testenv]
 usedevelop = True
+setenv = groups = All
 commands = {envpython} tests/unittests.py
-deps = -r{toxinidir}/requirements.txt
+deps =
+    -r{toxinidir}/requirements.txt
+    boto3
+# boto3 is provided by lambda runtime and thus not in requirements.txt file
+
 
 [testenv:flake8]
 commands = flake8 enhanced_rds tests


### PR DESCRIPTION
* change the structure of zip for imports to work in python3.7 runtime 
* add boto3 to tests requirements 
* change how we decide which db engine this is (aurora-postresql was not properly recognized)
* update copyrights
* version bump